### PR TITLE
Final fix

### DIFF
--- a/urbanparks/model/DateUtils.java
+++ b/urbanparks/model/DateUtils.java
@@ -7,7 +7,7 @@ import static urbanparks.model.ModelConstants.*;
 
 /**
  * Class that contains all the methods that is not belonging to the other classes.
- * invariants: all fields non-null
+ * invariants: none
  */
 public class DateUtils {
 

--- a/urbanparks/model/DateUtils.java
+++ b/urbanparks/model/DateUtils.java
@@ -7,6 +7,7 @@ import static urbanparks.model.ModelConstants.*;
 
 /**
  * Class that contains all the methods that is not belonging to the other classes.
+ * invariants: all fields non-null
  */
 public class DateUtils {
 

--- a/urbanparks/model/JobCollection.java
+++ b/urbanparks/model/JobCollection.java
@@ -155,16 +155,19 @@ public class JobCollection implements Serializable {
 		ArrayList<JobAvailability> availableJobs = new ArrayList<JobAvailability>();
 		for(Map.Entry<Long, Job> entry : jobsList.entrySet()) {
 			Job job = entry.getValue();
-			JobAvailability ja = new JobAvailability(job);
-			// check the unvolunteer from job business rules
-			// jobs that violate business rules are marked as unavailable
-			if (volunteer.isAssociatedWithJob(job.getJobId())) {
-				if (!job.getIsCancelled() && job.isUnvolunteerEarlyEnough()) {
-					ja.setIsAvailable(true);
-				} else {
-					ja.setIsAvailable(false);
+			// no jobs that have started should be displayed to user
+			if (!job.hasJobStarted()) {
+				JobAvailability ja = new JobAvailability(job);
+				// check the unvolunteer from job business rules
+				// jobs that violate business rules are marked as unavailable
+				if (volunteer.isAssociatedWithJob(job.getJobId())) {
+					if (!job.getIsCancelled() && job.isUnvolunteerEarlyEnough()) {
+						ja.setIsAvailable(true);
+					} else {
+						ja.setIsAvailable(false);
+					}
+					availableJobs.add(ja);
 				}
-				availableJobs.add(ja);
 			}
 		}
 		sortJobsByStartDate(availableJobs);
@@ -184,17 +187,20 @@ public class JobCollection implements Serializable {
 		ArrayList<JobAvailability> availableJobs = new ArrayList<JobAvailability>();
 		for(Map.Entry<Long, Job> entry : jobsList.entrySet()) {
 			Job job = entry.getValue();
-			if (parkManager.isAssociatedWithJob(job.getJobId())) {
-				JobAvailability ja = new JobAvailability(job);
-				// check unsubmitting job business rules
-				// jobs that violate business rules are marked as unavailable
+			// no jobs that have started should be displayed to user
+			if (!job.hasJobStarted()) {
 				if (parkManager.isAssociatedWithJob(job.getJobId())) {
-					if (!job.getIsCancelled() && job.isUnsubmitEarlyEnough()) {
-						ja.setIsAvailable(true);
-					} else {
-						ja.setIsAvailable(false);
+					JobAvailability ja = new JobAvailability(job);
+					// check unsubmitting job business rules
+					// jobs that violate business rules are marked as unavailable
+					if (parkManager.isAssociatedWithJob(job.getJobId())) {
+						if (!job.getIsCancelled() && job.isUnsubmitEarlyEnough()) {
+							ja.setIsAvailable(true);
+						} else {
+							ja.setIsAvailable(false);
+						}
+						availableJobs.add(ja);
 					}
-					availableJobs.add(ja);
 				}
 			}
 		}

--- a/urbanparks/tests/JobTest.java
+++ b/urbanparks/tests/JobTest.java
@@ -1,13 +1,9 @@
 package urbanparks.tests;
 
 import static org.junit.Assert.*;
-
 import java.time.LocalDateTime;
-
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import urbanparks.model.Job;
 import urbanparks.model.ModelConstants;
 import urbanparks.model.Volunteer;

--- a/urbanparks/tests/VolunteerTest.java
+++ b/urbanparks/tests/VolunteerTest.java
@@ -20,13 +20,11 @@ import urbanparks.model.Volunteer;
 public class VolunteerTest {
 
 	private Volunteer volunteerNoJobs;
-	private Volunteer volunteerWithJobs;
 	private JobCollection jobCollection;
 
 	/* test jobs with various lengths, name scheme "testJob_{start date}_{end date}"  */
 	private Job testJob_minDaysInFuture_minDaysInFuture;
     private Job testJob_minDaysInFuture_minDaysInFuturePlusOne;
-    private Job testJob_minDaysInFuture_minDaysInFuturePlusMaxJobLength;
     private Job testJob_minDaysInFuturePlusOne_minDaysInFuturePlusOne;
 
 	@Before
@@ -35,12 +33,8 @@ public class VolunteerTest {
         volunteerNoJobs = new Volunteer("NoJobs", "Volunteer",
                 "test1@test.test", "1234567890");
 
-        volunteerWithJobs = new Volunteer("HasJobs", "Volunteer",
-                "test2@test.test", "0987654321");
-
         LocalDateTime MinDaysInFuture = LocalDateTime.now().plusDays(ModelConstants.MIN_DAYS_BEFORE_SIGNUP);
         LocalDateTime MinDaysInFuturePlusOne = LocalDateTime.now().plusDays(ModelConstants.MIN_DAYS_BEFORE_SIGNUP + 1);
-        LocalDateTime minDaysInFuturePlusMaxJobLength = LocalDateTime.now().plusDays(ModelConstants.MIN_DAYS_BEFORE_SIGNUP + ModelConstants.MAX_JOB_LENGTH);
 
         jobCollection = new JobCollection();
 
@@ -48,7 +42,6 @@ public class VolunteerTest {
                 "Gasworks", "Seattle");
         testJob_minDaysInFuture_minDaysInFuturePlusOne = new Job("A test job", MinDaysInFuture, MinDaysInFuturePlusOne,
                 "Gasworks", "Seattle");
-        testJob_minDaysInFuture_minDaysInFuturePlusMaxJobLength = new Job("A test job", MinDaysInFuture, minDaysInFuturePlusMaxJobLength, "Gasworks", "Seattle");
         testJob_minDaysInFuturePlusOne_minDaysInFuturePlusOne = new Job("A test job", MinDaysInFuturePlusOne, MinDaysInFuturePlusOne,
                 "Gasworks", "Seattle");
 	}

--- a/urbanparks/view/parkmanager/CreateJobPane.java
+++ b/urbanparks/view/parkmanager/CreateJobPane.java
@@ -86,8 +86,8 @@ public class CreateJobPane extends GridPane {
         // create start and end date pickers
         startDatePicker = new DatePicker();
         endDatePicker = new DatePicker();
-        startDatePicker.setValue(LocalDate.now());
-        endDatePicker.setValue(LocalDate.now());
+        startDatePicker.setValue(LocalDate.now().plusDays(1));
+        endDatePicker.setValue(LocalDate.now().plusDays(1));
 
         // set up start date picker
         startDatePicker.valueProperty().addListener((arg0, oldValue, newValue) -> {
@@ -339,7 +339,7 @@ public class CreateJobPane extends GridPane {
         		LocalDateTime startDateTime = startDatePicker.getValue().atTime(startTime);
         		LocalDateTime endDateTime = endDatePicker.getValue().atTime(endTime);
 
-        		if (startDateTime.isBefore(endDateTime)) {
+        		if (startDateTime.isBefore(endDateTime) && startDateTime.isAfter(LocalDateTime.now())) {
                 	timesValid = true;
         		}
         	}	


### PR DESCRIPTION
Made all volunteer and park manager job view tables not show jobs that have started.
In requirements: 
As a Volunteer I want to view the future jobs that I have signed up for.
As a Volunteer I want to unvolunteer for a job I previously signed up for that has not yet occurred.
As a Park Manager I want to view the future jobs that I have submitted.